### PR TITLE
Refactor banned-word validation: use remote Banned-words-list/

### DIFF
--- a/.github/workflows/sync-banned-words.yml
+++ b/.github/workflows/sync-banned-words.yml
@@ -1,4 +1,4 @@
-name: Sync Hard Banned Words
+name: Sync Banned Words (Suspicious Check)
 
 on:
   schedule:
@@ -54,6 +54,6 @@ jobs:
           if git diff --cached --quiet; then
             echo "No changes"
           else
-            git commit -m "chore: sync hard-banned words [$(date -u '+%Y-%m-%d')]"
+            git commit -m "chore: sync hard-banned words for suspicious checks [$(date -u '+%Y-%m-%d')]"
             git push
           fi

--- a/.github/workflows/validate-issue.yml
+++ b/.github/workflows/validate-issue.yml
@@ -71,54 +71,74 @@ jobs:
                 }
               }
 
-              const bannedDir = path.join(process.env.GITHUB_WORKSPACE, 'banned-words');
-              if (fs.existsSync(bannedDir) && fs.statSync(bannedDir).isDirectory()) {
-                const files = fs.readdirSync(bannedDir).filter(f => f.endsWith('.txt'));
-                const patterns = [];
+              function matchPattern(pattern, str) {
+                if (pattern.includes('&&')) {
+                  const parts = pattern.split('&&').map(p => p.trim()).filter(Boolean);
+                  return parts.every(p => matchPattern(p, str));
+                }
 
-                for (const file of files) {
-                  const content = fs.readFileSync(path.join(bannedDir, file), 'utf8');
-                  content
-                    .split('\n')
+                if (pattern.includes('*') || pattern.includes('+')) {
+                  const reStr = pattern
+                    .replace(/[.^${}()|[\]\\]/g, '\\$&')
+                    .replace(/\*/g, '[\\s\\S]*')
+                    .replace(/\+/g, '[^\\s]+');
+
+                  const startsWild = pattern[0] === '*' || pattern[0] === '+';
+                  const endsWild   = pattern[pattern.length - 1] === '*' || pattern[pattern.length - 1] === '+';
+
+                  let re;
+                  if (startsWild || endsWild) {
+                    try { re = new RegExp(reStr, 'i'); } catch { return false; }
+                    return re.test(str);
+                  } else {
+                    try { re = new RegExp('^' + reStr + '$', 'i'); } catch { return false; }
+                    return re.test(str);
+                  }
+                }
+
+                return str === pattern;
+              }
+
+              const input = heroName.toLowerCase();
+
+              // Check against remote Banned-words-list/ for Valid/Invalid decision
+              const bannedRepo = process.env.BANNED_WORDS_REPO || 'readme-SVG/Banned-words';
+              const bannedBranch = process.env.BANNED_WORDS_BRANCH || 'main';
+              try {
+                const treeRes = await fetch(
+                  `https://api.github.com/repos/${bannedRepo}/git/trees/${bannedBranch}?recursive=1`,
+                  { headers: { 'User-Agent': 'issue-validator' } }
+                );
+                if (!treeRes.ok) throw new Error(`tree fetch failed: ${treeRes.status}`);
+
+                const tree = await treeRes.json();
+                const txtFiles = (tree.tree || []).filter(
+                  f => f.type === 'blob' && f.path.startsWith('Banned-words-list/') && f.path.endsWith('.txt')
+                );
+
+                const contents = await Promise.all(
+                  txtFiles.map(f =>
+                    fetch(
+                      `https://raw.githubusercontent.com/${bannedRepo}/${bannedBranch}/${f.path}`,
+                      { headers: { 'User-Agent': 'issue-validator' } }
+                    ).then(r => r.ok ? r.text() : '')
+                  )
+                );
+
+                const remotePatterns = [];
+                for (const text of contents) {
+                  text.split('\n')
                     .map(l => l.trim().toLowerCase())
                     .filter(Boolean)
-                    .forEach(line => patterns.push(line));
+                    .forEach(p => remotePatterns.push(p));
                 }
 
-                const input = heroName.toLowerCase();
-
-                function matchPattern(pattern, str) {
-                  if (pattern.includes('&&')) {
-                    const parts = pattern.split('&&').map(p => p.trim()).filter(Boolean);
-                    return parts.every(p => matchPattern(p, str));
-                  }
-
-                  if (pattern.includes('*') || pattern.includes('+')) {
-                    const reStr = pattern
-                      .replace(/[.^${}()|[\]\\]/g, '\\$&')
-                      .replace(/\*/g, '[\\s\\S]*')
-                      .replace(/\+/g, '[^\\s]+');
-
-                    const startsWild = pattern[0] === '*' || pattern[0] === '+';
-                    const endsWild   = pattern[pattern.length - 1] === '*' || pattern[pattern.length - 1] === '+';
-
-                    let re;
-                    if (startsWild || endsWild) {
-                      try { re = new RegExp(reStr, 'i'); } catch { return false; }
-                      return re.test(str);
-                    } else {
-                      try { re = new RegExp('^' + reStr + '$', 'i'); } catch { return false; }
-                      return re.test(str);
-                    }
-                  }
-
-                  return str === pattern;
-                }
-
-                const found = patterns.find(p => matchPattern(p, input));
+                const found = remotePatterns.find(p => matchPattern(p, input));
                 if (found) {
                   errors.push('- Username contains a banned word.');
                 }
+              } catch (e) {
+                console.warn(`Failed to fetch remote banned words: ${e.message}`);
               }
             }
 
@@ -202,4 +222,31 @@ jobs:
                 issue_number: issue.number,
                 body: '❌ **Validation failed.** Please edit your issue to fix the following:\n\n' + errors.join('\n')
               });
+            }
+
+            // Suspicious check: local banned-words/ (informational only, no label change)
+            if (heroName) {
+              const bannedDir = path.join(process.env.GITHUB_WORKSPACE, 'banned-words');
+              if (fs.existsSync(bannedDir) && fs.statSync(bannedDir).isDirectory()) {
+                const localFiles = fs.readdirSync(bannedDir).filter(f => f.endsWith('.txt'));
+                const localInput = heroName.toLowerCase();
+
+                for (const file of localFiles) {
+                  const content = fs.readFileSync(path.join(bannedDir, file), 'utf8');
+                  const localPatterns = content
+                    .split('\n')
+                    .map(l => l.trim().toLowerCase())
+                    .filter(Boolean);
+
+                  const suspiciousMatch = localPatterns.find(p => matchPattern(p, localInput));
+                  if (suspiciousMatch) {
+                    await github.rest.issues.createComment({
+                      owner: context.repo.owner, repo: context.repo.repo,
+                      issue_number: issue.number,
+                      body: `⚠️ **Suspicious:** Username matched a pattern in local dictionaries (file: \`banned-words/${file}\`, pattern: \`${suspiciousMatch}\`). This does not affect validation status — it is logged for manual review only.`
+                    });
+                    break;
+                  }
+                }
+              }
             }

--- a/api/index.js
+++ b/api/index.js
@@ -140,7 +140,7 @@ const BANNED_CACHE_TTL = 60_000;
 /**
  * Loads banned-word patterns from the configured GitHub repository with TTL caching.
  *
- * The loader retrieves every `.txt` file under `Hard-Banned-words-list/`,
+ * The loader retrieves every `.txt` file under `Banned-words-list/`,
  * normalizes each entry to lowercase, removes duplicates, and stores the result
  * in a short-lived in-memory cache to reduce GitHub API traffic on repeated
  * requests.
@@ -178,7 +178,7 @@ async function loadBannedPatterns() {
 
         const tree = await treeRes.json();
         const txtFiles = (tree.tree || []).filter(
-            f => f.type === 'blob' && f.path.startsWith('Hard-Banned-words-list/') && f.path.endsWith('.txt')
+            f => f.type === 'blob' && f.path.startsWith('Banned-words-list/') && f.path.endsWith('.txt')
         );
 
         const contents = await Promise.all(


### PR DESCRIPTION
## Summary

- **validate-issue.yml**: Valid/Invalid decision now checks against remote `Banned-words-list/*.txt` from `readme-SVG/Banned-words` instead of local `banned-words/` directory. This reduces false positives (e.g. "Ndeeviat" being flagged by `via*` pattern).
- **validate-issue.yml**: Added informational "Suspicious" comment when a username matches local `banned-words/*.txt` patterns — no label change, just logged for manual review.
- **api/index.js**: `loadBannedPatterns()` now fetches from `Banned-words-list/` instead of `Hard-Banned-words-list/`.
- **sync-banned-words.yml**: Clarified that local sync (Hard-Banned-words-list → banned-words/) is now only used for Suspicious checks.

## Data flow

```
Username submitted via issue
│
├─► Check against remote Banned-words-list/*.txt
│     ├─ Match → Invalid label + error comment
│     └─ No match → continue validation → Valid label
│
└─► Check against local banned-words/*.txt (informational only)
      ├─ Match → Suspicious comment (no label change)
      └─ No match → no comment
```

## Test plan

- [ ] Submit an issue with a username that matches a `Banned-words-list/` pattern → should get Invalid label
- [ ] Submit an issue with a clean username → should get Valid label
- [ ] Submit a username like "Ndeeviat" that only matches local `via*` → should get Valid label + Suspicious comment
- [ ] Verify API SVG output filters names using remote `Banned-words-list/` patterns only
- [ ] Verify sync workflow still runs and populates local `banned-words/`

https://claude.ai/code/session_01En8NUnemCvwB5Kd7zJJSFd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow display names and commit messages for improved clarity in issue tracking.

* **New Features**
  * Added informational "Suspicious check" flag during issue validation to alert about matched patterns without affecting validation status.

* **Refactor**
  * Updated banned-word validation to fetch patterns from remote repository for centralized list management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->